### PR TITLE
Dynamically determining the `ContentType` based on the current Protocol 

### DIFF
--- a/src/main/java/com/arangodb/springframework/boot/autoconfigure/ArangoAutoConfiguration.java
+++ b/src/main/java/com/arangodb/springframework/boot/autoconfigure/ArangoAutoConfiguration.java
@@ -20,7 +20,9 @@
 package com.arangodb.springframework.boot.autoconfigure;
 
 import com.arangodb.ArangoDB;
+import com.arangodb.ContentType;
 import com.arangodb.config.HostDescription;
+import com.arangodb.internal.serde.ContentTypeFactory;
 import com.arangodb.springframework.config.ArangoConfiguration;
 import com.arangodb.springframework.core.ArangoOperations;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -71,6 +73,11 @@ public class ArangoAutoConfiguration {
             properties.getHosts().stream().map(HostDescription::parse)
                     .forEach(host -> builder.host(host.getHost(), host.getPort()));
             return builder;
+        }
+
+        @Override
+        public ContentType contentType() {
+            return ContentTypeFactory.of(properties.getProtocol());
         }
 
         @Override


### PR DESCRIPTION
# My Concern:
The documentation https://docs.arangodb.com/stable/develop/integrations/spring-data-arangodb/#configuration emphasizes the need to override the `ArangoConfiguration#contentType()` method when configuring the driver for a protocol with VPACK content type (e.g., VST, HTTP_VPACK, or HTTP2_VPACK).

# My Recommendation:
It is unwarranted for users to explicitly override the content type when opting for protocols like `VST, HTTP_VPACK, or HTTP2_VPACK`. Instead, this information must be seamlessly retrieved from the existing configuration. Moreover, the obligatory override of the `ArangoConfiguration` unnecessarily compels users to also override the `database` and `ArangoDB.Builder` methods, a requirement that can be deemed superfluous.